### PR TITLE
fix wrong list for waf_cert

### DIFF
--- a/plugins/modules/waf_certificate_info.py
+++ b/plugins/modules/waf_certificate_info.py
@@ -73,7 +73,9 @@ class WafCertificateInfoModule(OTCModule):
             raw = self.conn.waf.find_certificate(
                 self.params['name'], ignore_missing=True)
             if raw:
-                data.append(raw.to_dict().pop('location'))
+                dt = raw.to_dict()
+                dt.pop('location')
+                data.append(dt)
         else:
             for raw in self.conn.waf.certificates():
                 dt = raw.to_dict()

--- a/tests/integration/targets/waf_certificate/tasks/main.yaml
+++ b/tests/integration/targets/waf_certificate/tasks/main.yaml
@@ -76,12 +76,18 @@
         private_key: "{{ key }}"
       register: result
 
+    - name: Get cert info
+      waf_certificate_info:
+        name: "{{ cert_name }}"
+      register: result_info
+
     - name: assert result
       assert:
         that:
           - result is success
           - result is changed
           - result.waf_certificate is defined
+          - result_info.waf_certificates[0].name == cert_name
 
     - name: Drop cert
       waf_certificate:


### PR DESCRIPTION
same error once in waf_domains:

```
ok: [localhost] => {
    "certificate_info": {
        "changed": false,
        "failed": false,
        "waf_certificates": [
            {
                "cloud": "envvars",
                "project": {
                    "domain_id": null,
                    "domain_name": null,
                    "id": "019e712dac0a40b6b538050dae591948",
                    "name": "eu-de_prod"
                },
                "region_name": "",
                "zone": null
            }
        ]
    }
}
```