### PR TITLE
Correct vpc peering info module

### DIFF
--- a/plugins/modules/vpc_peering_info.py
+++ b/plugins/modules/vpc_peering_info.py
@@ -36,7 +36,7 @@ options:
     type: str
   router:
     description:
-      - Router name.
+      - Router name or id.
     type: str
 requirements: ["openstacksdk", "otcextensions"]
 '''
@@ -86,6 +86,10 @@ EXAMPLES = '''
 - vpc_peering_info:
     name: vpc_peering1
   register: vpc_peering
+  
+- vpc_peering_info:
+    router: "76889f64a23945ab887012be95acf"
+  register: vpc_peering
 '''
 
 from ansible_collections.opentelekomcloud.cloud.plugins.module_utils.otc import OTCModule
@@ -115,7 +119,8 @@ class VPCPeeringInfoModule(OTCModule):
         if project_id_filter:
             query['project_id'] = project_id_filter
         if router:
-            query['router_id'] = self.conn.network.find_router(router)
+            router_obj = self.conn.network.find_router(router)
+            query['vpc_id'] = router_obj['id']
 
         for raw in self.conn.vpc.peerings(**query):
             dt = raw.to_dict()

--- a/plugins/modules/vpc_peering_info.py
+++ b/plugins/modules/vpc_peering_info.py
@@ -86,7 +86,6 @@ EXAMPLES = '''
 - vpc_peering_info:
     name: vpc_peering1
   register: vpc_peering
-  
 - vpc_peering_info:
     router: "76889f64a23945ab887012be95acf"
   register: vpc_peering


### PR DESCRIPTION
Add filtering by name or id of router instead of only name  to vpc peering info module