### PR TITLE
Allow not waiting for RDS

### DIFF
--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -209,7 +209,10 @@ class RdsInstanceModule(OTCModule):
         return False
 
     def run(self):
-        self.params['wait_timeout'] = self.params.pop('timeout')
+        if self.params['wait']:
+            self.params['wait_timeout'] = self.params.pop('timeout')
+        else:
+            self.params.pop('timeout')
         name = self.params['name']
 
         changed = False


### PR DESCRIPTION
- VPC peering fix
- Allow not setting wait for rds_instance
