### PR TITLE
Add role metadata

### DIFF
--- a/roles/vpc_peering/README.rst
+++ b/roles/vpc_peering/README.rst
@@ -1,4 +1,34 @@
+opentelekomcloud.cloud.vpc_peering
+==================================
+
 Configure VPC Peering between 2 routers.
+
+Requirements
+------------
+
+Python packages:
+  - openstacksdk
+  - otcextensions
+
+Ansible collections:
+  - openstack.cloud
+  - opentelekomcloud.cloud
+
+Role Variables
+--------------
+
+cloud_a: Connection to cloud A
+local_router: Name or ID of the router on side A
+local_project: Name or ID of the project of the side A
+local_cidr: CIDR for the route
+cloud_b: Connection to the cloud B
+remote_router: Name or ID of the router on side B
+remote_cidr: CIDR for the route
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
 
 Role is designed to work best looping over the structure of peering
 definitions:
@@ -27,11 +57,7 @@ definitions:
          loop_control:
            loop_var: vpcp
 
-**Role Variables**
-cloud_a: Connection to cloud A
-local_router: Name or ID of the router on side A
-local_project: Name or ID of the project of the side A
-local_cidr: CIDR for the route
-cloud_b: Connection to the cloud B
-remote_router: Name or ID of the router on side B
-remote_cidr: CIDR for the route
+License
+-------
+
+Apache-2.0

--- a/roles/vpc_peering/meta/main.yml
+++ b/roles/vpc_peering/meta/main.yml
@@ -1,0 +1,10 @@
+galaxy_info:
+  author: Artem Goncharov
+  description: Manage VPC Peering between 2 VPCs in the Open Telekom Cloud
+  company: Open Telekom Cloud
+
+  license: Apache-2.0
+
+  min_ansible_version: 2.10
+
+dependencies: []


### PR DESCRIPTION
Galaxy starts compaining about absence of the role data. Add it to keep
it happy.
