### PR TITLE
Pin sphinx

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,2 @@
 otcdocstheme # Ansible-2.0
+Sphinx==3.5.4 # BSD


### PR DESCRIPTION
Zuul reno jobs are not using contraints. This results in another version
of Sphinx used, what results in double header on the page.
