### PR TITLE
Support passing vpc by name to `subnet`

### DIFF
--- a/tests/integration/targets/subnet/tasks/main.yaml
+++ b/tests/integration/targets/subnet/tasks/main.yaml
@@ -27,7 +27,7 @@
       opentelekomcloud.cloud.subnet:
         name: "{{ subnet_name }}"
         description: "Subnet example"
-        vpc_id: "{{ vpc.vpc.id }}"
+        vpc: "{{ vpc_name }}"
         cidr: "{{ cidr }}"
         gateway_ip: "{{ gateway }}"
         dns_list:
@@ -46,7 +46,7 @@
       opentelekomcloud.cloud.subnet:
         name: "{{ subnet_name }}"
         description: "Subnet example"
-        vpc_id: "{{ vpc.vpc.id }}"
+        vpc: "{{ vpc_name }}"
         cidr: "{{ cidr }}"
         gateway_ip: "{{ gateway }}"
         dns_list:
@@ -65,7 +65,7 @@
     - name: Update subnet
       opentelekomcloud.cloud.subnet:
         name: "{{ subnet_name }}"
-        vpc_id: "{{ vpc.vpc.id }}"
+        vpc: "{{ vpc_name }}"
         dns_list:
           - "100.125.4.25"
           - "100.125.129.199"
@@ -82,7 +82,7 @@
     - name: Delete subnet
       opentelekomcloud.cloud.subnet:
         name: "{{ subnet_name }}"
-        vpc_id: "{{ vpc.vpc.id }}"
+        vpc: "{{ vpc_name }}"
         state: absent
       register: deleted_subnet
 
@@ -95,7 +95,7 @@
     - name: Check deleted subnet
       opentelekomcloud.cloud.subnet:
         name: "{{ subnet_name }}"
-        vpc_id: "{{ vpc.vpc.id }}"
+        vpc: "{{ vpc_name }}"
         state: absent
       register: deleted_subnet_check
       check_mode: true


### PR DESCRIPTION
Allow passing VPC to `subnet` module either by name or by ID

Resolve #165