### PR TITLE
DNM: Cap ansible-lint lower then 6.8.6

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 openstacksdk
-ansible-lint>=6.0.0
+ansible-lint>=6.0.0,<6.8.6
 pycodestyle==2.8.0
 flake8>=4.0.0
 pylint


### PR DESCRIPTION
Verify whether latest ansible-lint is breaking our tests