### PR TITLE
README.md: Add setuptools as requirement to pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ source ansiblevenv/bin/activate
 Install ``wheel``, ``ansible`` and ``otcextensions``:
 
 ```bash
-(ansiblevenv) $ pip install wheel ansible otcextensions
+(ansiblevenv) $ pip install wheel ansible otcextensions setuptools
 ```
 
 Install opentelekomcloud.cloud collection from Ansible-Galaxy:


### PR DESCRIPTION
Thank you for providing this ansible collection!

When following the "Get started on a blank system in a Python virtual environment" guide on an installation of Ubuntu 24.04, I still ran into the error "openstacksdk and otcextensions are required for this self".
A search of this repository pointed me to the file plugins/module_utils/otc.py that showed, that there are several imports, that are checked in one condition.
When trying these one by one, I found, that the import from pkg_resources was failing, which is apparently caused by a missing installation of the setuptools package.
After installing this package, everything worked like a charm, so I found, that this tip might help others to use this collection.