### PR TITLE
Map rds disk_encryption parameter into disk_encryption_id

### DIFF
--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -245,6 +245,8 @@ class RdsInstanceModule(OTCModule):
             if volume_type:
                 self.params['volume_type'] = volume_type.upper()
 
+            self.params["disk_encryption_id"] = self.params['disk_encryption']
+
             instance = self.conn.create_rds_instance(**self.params)
             self.exit(changed=True, instance=instance.to_dict())
 


### PR DESCRIPTION
The underlying API (otcextensions) uses `disk_encryption_id` as parameter name instead of `disk_encryption`. The value needs to be copied so that it will be respected.

See https://github.com/opentelekomcloud/ansible-collection-cloud/blob/b3cdedddf88df851c75384631744c20f63ff6f85/plugins/modules/dds_instance.py#L215 where something similar is done for DDS.

Fixes #382 